### PR TITLE
Removed duplicate splitting

### DIFF
--- a/lib/chef/knife/digital_ocean_droplet_create.rb
+++ b/lib/chef/knife/digital_ocean_droplet_create.rb
@@ -200,7 +200,7 @@ class Chef
                                           size: locate_config_value(:size),
                                           image: locate_config_value(:image),
                                           region: locate_config_value(:location),
-                                          ssh_keys: locate_config_value(:ssh_key_ids).split(/, ?/),
+                                          ssh_keys: locate_config_value(:ssh_key_ids),
                                           private_networking: locate_config_value(:private_networking),
                                           backups: locate_config_value(:backups),
                                           ipv6: locate_config_value(:ipv6)


### PR DESCRIPTION
Splitting SSH key IDs is currently done twice - while processing options and when sending key IDs to API.
This leads to nested array - which currently DO API rejects. This PR removes second splitting, leading the one and original splitting of string to array while processing options.

Should offer fix for issues #62 and #63 