### PR TITLE
use camelcase for ZeroBootstrap

### DIFF
--- a/lib/chef/knife/digital_ocean_droplet_create.rb
+++ b/lib/chef/knife/digital_ocean_droplet_create.rb
@@ -25,7 +25,7 @@ class Chef
         # Knife loads subcommands automatically, so we can just check if the
         # class exists.
         Chef::Knife::SoloBootstrap.load_deps if defined? Chef::Knife::SoloBootstrap
-        Chef::Knife::Zerobootstrap.load_deps if defined? Chef::Knife::Zerobootstrap
+        Chef::Knife::ZeroBootstrap.load_deps if defined? Chef::Knife::ZeroBootstrap
       end
 
       banner 'knife digital_ocean droplet create (options)'


### PR DESCRIPTION
Hi,

I've wrote fix for https://github.com/rmoriz/knife-digital_ocean/issues/58 .

And one more setting, Current version of the knife-zero needs override distro to chef-full-localmode.

```
knife[:distro] = 'chef-full-localmode'

or
pass via option ` --distro chef-full-localmode`
```

I've success bootstrap like below.

```
$ knife digital_ocean droplet create --zero -N knifezero.gregf.org -L nyc3 -S 512mb -K $DIGITALOCEAN_SSH_KEY_IDS -I debian-7-0-x64 -r 'recipe[apt]' --identity-file ~/.ssh/my_key
```
