### PR TITLE
fix typo in digital_ocean_droplet_destroy.rb

### DIFF
--- a/lib/chef/knife/digital_ocean_droplet_destroy.rb
+++ b/lib/chef/knife/digital_ocean_droplet_destroy.rb
@@ -47,7 +47,7 @@ class Chef
           exit 1
         end
 
-        if droplet_ids.empty?
+        if droplets_ids.empty?
           ui.error('Could not find any droplet(s)')
           exit 1
         end


### PR DESCRIPTION
There were the issue with deleting droplets because of typo:

```
Exception: NameError: undefined local variable or method `droplet_ids' for #<Chef::Knife::DigitalOceanDropletDestroy:0x007fee592f1cd8>
```