### PR TITLE
Use proper capitalization in sshkey create error messages

### DIFF
--- a/lib/chef/knife/digital_ocean_sshkey_create.rb
+++ b/lib/chef/knife/digital_ocean_sshkey_create.rb
@@ -36,12 +36,12 @@ class Chef
         validate!
 
         unless locate_config_value(:name)
-          ui.error('SSH Key name cannot be empty. => -N <sshkey-name>')
+          ui.error('SSH Key name cannot be empty. => -n <sshkey-name>')
           exit 1
         end
 
         unless locate_config_value(:public_key)
-          ui.error('SSH key file needs to be specified. => -I <public_key>')
+          ui.error('SSH key file needs to be specified. => -i <public_key>')
           exit 1
         end
 


### PR DESCRIPTION
Other specs weren't passing locally, but this should be correct.